### PR TITLE
Update references to Go 1.24 for stable release

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,12 @@ end-users. This SDK is an alpha product.
 
 -   \[Required] [Go](https://go.dev/): v1.24+ - This SDK leverages Go 1.24's
     support for [WASI](https://github.com/WebAssembly/WASI) (WebAssembly System
-    Interface) reactors. You can grab a release candidate from the
-    [Go unstable releases page](https://go.dev/dl/#unstable). A stable release
-    of Go 1.24 is
-    [expected in February 2025](https://tip.golang.org/doc/go1.24).
--   \[Required] A host environment supporting this toolchain - This SDK
-    leverages additional host imports added to the proxy-wasm-cpp-host in
-    [PR#427](https://github.com/proxy-wasm/proxy-wasm-cpp-host/pull/427). This
-    has yet to be merged, let alone make its way downstream to Envoy, ATS,
-    nginx, or managed environments.
+    Interface) reactors. You can install a suitable version from the
+    [Go installation guide](https://go.dev/doc/install).
+-   \[Required] A host environment supporting this toolchain, such as Envoy >=
+    1.33.0. This SDK leverages additional host imports added to the
+    proxy-wasm-cpp-host in
+    [PR#427](https://github.com/proxy-wasm/proxy-wasm-cpp-host/pull/427).
 -   \[Optional] [Envoy](https://www.envoyproxy.io) - To run end-to-end tests,
     you need to have an Envoy binary. You can use [func-e](https://func-e.io) as
     an easy way to get started with Envoy or follow

--- a/examples/dispatch_call_on_tick/go.mod
+++ b/examples/dispatch_call_on_tick/go.mod
@@ -1,12 +1,12 @@
 module github.com/proxy-wasm/proxy-wasm-go-sdk/examples/dispatch_call_on_tick
 
-go 1.24rc1
+go 1.24
 
 replace github.com/proxy-wasm/proxy-wasm-go-sdk => ../..
 
 require (
-	github.com/stretchr/testify v1.9.0
 	github.com/proxy-wasm/proxy-wasm-go-sdk v0.0.0-00010101000000-000000000000
+	github.com/stretchr/testify v1.9.0
 )
 
 require (

--- a/examples/foreign_call_on_tick/go.mod
+++ b/examples/foreign_call_on_tick/go.mod
@@ -1,12 +1,12 @@
 module github.com/proxy-wasm/proxy-wasm-go-sdk/examples/foreign_call_on_tick
 
-go 1.24rc1
+go 1.24
 
 replace github.com/proxy-wasm/proxy-wasm-go-sdk => ../..
 
 require (
-	github.com/stretchr/testify v1.9.0
 	github.com/proxy-wasm/proxy-wasm-go-sdk v0.0.0-00010101000000-000000000000
+	github.com/stretchr/testify v1.9.0
 )
 
 require (

--- a/examples/helloworld/go.mod
+++ b/examples/helloworld/go.mod
@@ -1,12 +1,12 @@
 module github.com/proxy-wasm/proxy-wasm-go-sdk/examples/helloworld
 
-go 1.24rc1
+go 1.24
 
 replace github.com/proxy-wasm/proxy-wasm-go-sdk => ../..
 
 require (
-	github.com/stretchr/testify v1.9.0
 	github.com/proxy-wasm/proxy-wasm-go-sdk v0.0.0-00010101000000-000000000000
+	github.com/stretchr/testify v1.9.0
 )
 
 require (

--- a/examples/http_auth_random/go.mod
+++ b/examples/http_auth_random/go.mod
@@ -1,12 +1,12 @@
 module github.com/proxy-wasm/proxy-wasm-go-sdk/examples/http_auth_random
 
-go 1.24rc1
+go 1.24
 
 replace github.com/proxy-wasm/proxy-wasm-go-sdk => ../..
 
 require (
-	github.com/stretchr/testify v1.9.0
 	github.com/proxy-wasm/proxy-wasm-go-sdk v0.0.0-00010101000000-000000000000
+	github.com/stretchr/testify v1.9.0
 )
 
 require (

--- a/examples/http_body/go.mod
+++ b/examples/http_body/go.mod
@@ -1,12 +1,12 @@
 module github.com/proxy-wasm/proxy-wasm-go-sdk/examples/http_body
 
-go 1.24rc1
+go 1.24
 
 replace github.com/proxy-wasm/proxy-wasm-go-sdk => ../..
 
 require (
-	github.com/stretchr/testify v1.9.0
 	github.com/proxy-wasm/proxy-wasm-go-sdk v0.0.0-00010101000000-000000000000
+	github.com/stretchr/testify v1.9.0
 )
 
 require (

--- a/examples/http_body_chunk/go.mod
+++ b/examples/http_body_chunk/go.mod
@@ -1,12 +1,12 @@
 module github.com/proxy-wasm/proxy-wasm-go-sdk/examples/http_body_chunk
 
-go 1.24rc1
+go 1.24
 
 replace github.com/proxy-wasm/proxy-wasm-go-sdk => ../..
 
 require (
-	github.com/stretchr/testify v1.9.0
 	github.com/proxy-wasm/proxy-wasm-go-sdk v0.0.0-00010101000000-000000000000
+	github.com/stretchr/testify v1.9.0
 )
 
 require (

--- a/examples/http_headers/go.mod
+++ b/examples/http_headers/go.mod
@@ -1,12 +1,12 @@
 module github.com/proxy-wasm/proxy-wasm-go-sdk/examples/http_headers
 
-go 1.24rc1
+go 1.24
 
 replace github.com/proxy-wasm/proxy-wasm-go-sdk => ../..
 
 require (
-	github.com/stretchr/testify v1.9.0
 	github.com/proxy-wasm/proxy-wasm-go-sdk v0.0.0-00010101000000-000000000000
+	github.com/stretchr/testify v1.9.0
 	github.com/tidwall/gjson v1.14.3
 )
 

--- a/examples/http_routing/go.mod
+++ b/examples/http_routing/go.mod
@@ -1,12 +1,12 @@
 module github.com/proxy-wasm/proxy-wasm-go-sdk/examples/http_routing
 
-go 1.24rc1
+go 1.24
 
 replace github.com/proxy-wasm/proxy-wasm-go-sdk => ../..
 
 require (
-	github.com/stretchr/testify v1.9.0
 	github.com/proxy-wasm/proxy-wasm-go-sdk v0.0.0-00010101000000-000000000000
+	github.com/stretchr/testify v1.9.0
 )
 
 require (

--- a/examples/json_validation/go.mod
+++ b/examples/json_validation/go.mod
@@ -1,12 +1,12 @@
 module github.com/proxy-wasm/proxy-wasm-go-sdk/examples/json_validation
 
-go 1.24rc1
+go 1.24
 
 replace github.com/proxy-wasm/proxy-wasm-go-sdk => ../..
 
 require (
-	github.com/stretchr/testify v1.9.0
 	github.com/proxy-wasm/proxy-wasm-go-sdk v0.16.0
+	github.com/stretchr/testify v1.9.0
 	github.com/tidwall/gjson v1.14.1
 )
 

--- a/examples/metrics/go.mod
+++ b/examples/metrics/go.mod
@@ -1,12 +1,12 @@
 module github.com/proxy-wasm/proxy-wasm-go-sdk/examples/metrics
 
-go 1.24rc1
+go 1.24
 
 replace github.com/proxy-wasm/proxy-wasm-go-sdk => ../..
 
 require (
-	github.com/stretchr/testify v1.9.0
 	github.com/proxy-wasm/proxy-wasm-go-sdk v0.0.0-00010101000000-000000000000
+	github.com/stretchr/testify v1.9.0
 )
 
 require (

--- a/examples/multiple_dispatches/go.mod
+++ b/examples/multiple_dispatches/go.mod
@@ -1,12 +1,12 @@
 module github.com/proxy-wasm/proxy-wasm-go-sdk/examples/multiple_dispatches
 
-go 1.24rc1
+go 1.24
 
 replace github.com/proxy-wasm/proxy-wasm-go-sdk => ../..
 
 require (
-	github.com/stretchr/testify v1.9.0
 	github.com/proxy-wasm/proxy-wasm-go-sdk v0.0.0-00010101000000-000000000000
+	github.com/stretchr/testify v1.9.0
 )
 
 require (

--- a/examples/network/go.mod
+++ b/examples/network/go.mod
@@ -1,12 +1,12 @@
 module github.com/proxy-wasm/proxy-wasm-go-sdk/examples/network
 
-go 1.24rc1
+go 1.24
 
 replace github.com/proxy-wasm/proxy-wasm-go-sdk => ../..
 
 require (
-	github.com/stretchr/testify v1.9.0
 	github.com/proxy-wasm/proxy-wasm-go-sdk v0.0.0-00010101000000-000000000000
+	github.com/stretchr/testify v1.9.0
 )
 
 require (

--- a/examples/postpone_requests/go.mod
+++ b/examples/postpone_requests/go.mod
@@ -1,12 +1,12 @@
 module github.com/proxy-wasm/proxy-wasm-go-sdk/examples/postpone_requests
 
-go 1.24rc1
+go 1.24
 
 replace github.com/proxy-wasm/proxy-wasm-go-sdk => ../..
 
 require (
-	github.com/stretchr/testify v1.9.0
 	github.com/proxy-wasm/proxy-wasm-go-sdk v0.0.0-00010101000000-000000000000
+	github.com/stretchr/testify v1.9.0
 )
 
 require (

--- a/examples/properties/go.mod
+++ b/examples/properties/go.mod
@@ -1,12 +1,12 @@
 module github.com/proxy-wasm/proxy-wasm-go-sdk/examples/properties
 
-go 1.24rc1
+go 1.24
 
 replace github.com/proxy-wasm/proxy-wasm-go-sdk => ../..
 
 require (
-	github.com/stretchr/testify v1.9.0
 	github.com/proxy-wasm/proxy-wasm-go-sdk v0.0.0-00010101000000-000000000000
+	github.com/stretchr/testify v1.9.0
 )
 
 require (

--- a/examples/shared_data/go.mod
+++ b/examples/shared_data/go.mod
@@ -1,12 +1,12 @@
 module github.com/proxy-wasm/proxy-wasm-go-sdk/examples/shared_data
 
-go 1.24rc1
+go 1.24
 
 replace github.com/proxy-wasm/proxy-wasm-go-sdk => ../..
 
 require (
-	github.com/stretchr/testify v1.9.0
 	github.com/proxy-wasm/proxy-wasm-go-sdk v0.0.0-00010101000000-000000000000
+	github.com/stretchr/testify v1.9.0
 )
 
 require (

--- a/examples/shared_queue/go.mod
+++ b/examples/shared_queue/go.mod
@@ -1,6 +1,6 @@
 module github.com/proxy-wasm/proxy-wasm-go-sdk/examples/shared_queue
 
-go 1.24rc1
+go 1.24
 
 replace github.com/proxy-wasm/proxy-wasm-go-sdk => ../..
 

--- a/examples/vm_plugin_configuration/go.mod
+++ b/examples/vm_plugin_configuration/go.mod
@@ -1,12 +1,12 @@
 module github.com/proxy-wasm/proxy-wasm-go-sdk/examples/vm_plugin_configuration
 
-go 1.24rc1
+go 1.24
 
 replace github.com/proxy-wasm/proxy-wasm-go-sdk => ../..
 
 require (
-	github.com/stretchr/testify v1.9.0
 	github.com/proxy-wasm/proxy-wasm-go-sdk v0.0.0-00010101000000-000000000000
+	github.com/stretchr/testify v1.9.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/proxy-wasm/proxy-wasm-go-sdk
 
-go 1.24rc1
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.9.0


### PR DESCRIPTION
Go 1.24 was released 2025-02-11: https://go.dev/blog/go1.24